### PR TITLE
[ReactiveCocoa] Adds reactive cocoa support

### DIFF
--- a/Moya-ObjectMapper.podspec
+++ b/Moya-ObjectMapper.podspec
@@ -33,4 +33,11 @@ Pod::Spec.new do |s|
     ss.dependency "Moya-ObjectMapper/Core"
     ss.dependency "RxSwift", "2.0.0-beta.4"
   end
+
+  s.subspec "ReactiveCocoa" do |ss|
+    ss.source_files = "Source/ReactiveCocoa/*.swift"
+    ss.dependency "Moya/ReactiveCocoa", "~> 5.1.0"
+    ss.dependency "Moya-ObjectMapper/Core"
+    ss.dependency "ReactiveCocoa", "4.0.4-alpha-4"
+  end
 end


### PR DESCRIPTION
Adds reactive cocoa support. There is no demo project or test so I
can’t really test if it works as expected but it should since it almost
identical to my Argo mapping functions.

You will need to use `--allow-warnings` for the lint to pass for the
pod.