### PR TITLE
Removed observeOn methods

### DIFF
--- a/Source/RxSwift/Observable+ObjectMapper.swift
+++ b/Source/RxSwift/Observable+ObjectMapper.swift
@@ -13,25 +13,21 @@ import ObjectMapper
 /// Extension for processing Responses into Mappable objects through ObjectMapper
 public extension ObservableType where E == Response {
 
-  /// Maps data received from the signal into an object (on the default Background thread) which 
-  /// implements the Mappable protocol and returns the result back on the MainScheduler.
+  /// Maps data received from the signal into an object
+  /// which implements the Mappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
   public func mapObject<T: Mappable>(type: T.Type) -> Observable<T> {
-    return observeOn(SerialDispatchQueueScheduler(globalConcurrentQueueQOS: .Background))
-      .flatMap { response -> Observable<T> in
+    return flatMap { response -> Observable<T> in
         return Observable.just(try response.mapObject())
       }
-      .observeOn(MainScheduler.instance)
   }
 
-  /// Maps data received from the signal into an array of objects (on the default Background thread)
-  /// which implement the Mappable protocol and returns the result back on the MainScheduler
+  /// Maps data received from the signal into an array of objects
+  /// which implement the Mappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
   public func mapArray<T: Mappable>(type: T.Type) -> Observable<[T]> {
-    return observeOn(SerialDispatchQueueScheduler(globalConcurrentQueueQOS: .Background))
-      .flatMap { response -> Observable<[T]> in
+    return flatMap { response -> Observable<[T]> in
         return Observable.just(try response.mapArray())
       }
-      .observeOn(MainScheduler.instance)
   }
 }


### PR DESCRIPTION
This methods shouldn't change the observable's scheduler (observeOn), because this responsibility should be on the client side, otherwise you can end messing the client's requirements with the observable chain (self experience)