### PR TITLE
fixed RxSwift dependency version 2.2.0 ~> 2.2

### DIFF
--- a/Moya-ObjectMapper.podspec
+++ b/Moya-ObjectMapper.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
     ss.source_files = "Source/RxSwift/*.swift"
     ss.dependency "Moya/RxSwift", "~> 6.2.0"
     ss.dependency "Moya-ObjectMapper/Core"
-    ss.dependency "RxSwift", "~> 2.2.0"
+    ss.dependency "RxSwift", "~> 2.2"
   end
 
   s.subspec "ReactiveCocoa" do |ss|


### PR DESCRIPTION
it fails when used with updated versions of RxSwift e.g. 2.3.1