### PR TITLE
Added optional mapping of response data at non-empty keyPath

### DIFF
--- a/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
+++ b/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
@@ -7,18 +7,18 @@ extension SignalProducerType where Value == Moya.Response, Error == Moya.Error {
 
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: Mappable>(type: T.Type) -> SignalProducer<T, Error> {
+  public func mapObject<T: Mappable>(type: T.Type, keyPath: String? = nil) -> SignalProducer<T, Error> {
     return producer.flatMap(.Latest) { response -> SignalProducer<T, Error> in
-      return unwrapThrowable { try response.mapObject(T) }
+		return unwrapThrowable { try response.mapObject(T, withKeyPath: keyPath) }
     }
   }
 
   /// Maps data received from the signal into an array of objects which implement the Mappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: Mappable>(type: T.Type) -> SignalProducer<[T], Error> {
+  public func mapArray<T: Mappable>(type: T.Type, keyPath: String? = nil) -> SignalProducer<[T], Error> {
     return producer.flatMap(.Latest) { response -> SignalProducer<[T], Error> in
-      return unwrapThrowable { try response.mapArray(T) }
+      return unwrapThrowable { try response.mapArray(T, withKeyPath: keyPath) }
     }
   }
 }

--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -10,24 +10,48 @@ import Moya
 import ObjectMapper
 
 public extension Response {
-
-  /// Maps data received from the signal into an object which implements the Mappable protocol.
-  /// If the conversion fails, the signal errors.
-  public func mapObject<T: Mappable>(type: T.Type) throws -> T {
-    guard let object = Mapper<T>().map(try mapJSON()) else {
-      throw Error.JSONMapping(self)
-    }
-   return object
-  }
-
-  /// Maps data received from the signal into an array of objects which implement the Mappable
-  /// protocol.
-  /// If the conversion fails, the signal errors.
-  public func mapArray<T: Mappable>(type: T.Type) throws -> [T] {
-    guard let objects = Mapper<T>().mapArray(try mapJSON()) else {
-      throw Error.JSONMapping(self)
-    }
-    return objects
-  }
-
+	
+	/// Maps data received from the signal into an object which implements the Mappable protocol.
+	/// If the conversion fails, the signal errors.
+	public func mapObject<T: Mappable>(type: T.Type) throws -> T {
+		guard let object = Mapper<T>().map(try mapJSON()) else {
+			throw Error.JSONMapping(self)
+		}
+		return object
+	}
+	
+	// Map an object that sits at a non-empty keyPath inside the response JSON
+	public func mapObject<T: Mappable>(type: T.Type, withKeyPath keyPath: String?) throws -> T {
+		guard let keyPath = keyPath else { return try mapObject(type) }
+		
+		guard let jsonDictionary = try mapJSON() as? NSDictionary,
+			let objectDictionary = jsonDictionary.valueForKeyPath(keyPath) as? NSDictionary,
+			let object = Mapper<T>().map(objectDictionary) else {
+				throw Error.JSONMapping(self)
+		}
+		return object
+	}
+	
+	/// Maps data received from the signal into an array of objects which implement the Mappable
+	/// protocol.
+	/// If the conversion fails, the signal errors.
+	public func mapArray<T: Mappable>(type: T.Type) throws -> [T] {
+		guard let objects = Mapper<T>().mapArray(try mapJSON()) else {
+			throw Error.JSONMapping(self)
+		}
+		return objects
+	}
+	
+	// Map an array that sits at a non-empty keyPath inside the response JSON
+	public func mapArray<T: Mappable>(type: T.Type, withKeyPath keyPath: String?) throws -> [T] {
+		guard let keyPath = keyPath else { return try mapArray(type) }
+		
+		guard let jsonDictionary = try mapJSON() as? NSDictionary,
+			let objectArray = jsonDictionary.valueForKeyPath(keyPath) as? NSArray,
+			let objects = Mapper<T>().mapArray(objectArray) else {
+				throw Error.JSONMapping(self)
+		}
+		return objects
+	}
+	
 }

--- a/Source/RxSwift/Observable+ObjectMapper.swift
+++ b/Source/RxSwift/Observable+ObjectMapper.swift
@@ -13,21 +13,21 @@ import ObjectMapper
 /// Extension for processing Responses into Mappable objects through ObjectMapper
 public extension ObservableType where E == Response {
 
-  /// Maps data received from the signal into an object
-  /// which implements the Mappable protocol and returns the result back
-  /// If the conversion fails, the signal errors.
-  public func mapObject<T: Mappable>(type: T.Type) -> Observable<T> {
-    return flatMap { response -> Observable<T> in
-        return Observable.just(try response.mapObject(T))
-      }
-  }
-
-  /// Maps data received from the signal into an array of objects
-  /// which implement the Mappable protocol and returns the result back
-  /// If the conversion fails, the signal errors.
-  public func mapArray<T: Mappable>(type: T.Type) -> Observable<[T]> {
-    return flatMap { response -> Observable<[T]> in
-        return Observable.just(try response.mapArray(T))
-      }
-  }
+	/// Maps data received from the signal into an object
+	/// which implements the Mappable protocol and returns the result back
+	/// If the conversion fails, the signal errors.
+	public func mapObject<T: Mappable>(type: T.Type, keyPath: String? = nil) -> Observable<T> {
+		return flatMap { response -> Observable<T> in
+			return Observable.just(try response.mapObject(T, withKeyPath: keyPath))
+		}
+	}
+	
+	/// Maps data received from the signal into an array of objects
+	/// which implement the Mappable protocol and returns the result back
+	/// If the conversion fails, the signal errors.
+	public func mapArray<T: Mappable>(type: T.Type, keyPath: String? = nil) -> Observable<[T]> {
+		return flatMap { response -> Observable<[T]> in
+			return Observable.just(try response.mapArray(T, withKeyPath: keyPath))
+		}
+	}
 }


### PR DESCRIPTION
This fork is heavily inspired by [Moya-ModelMapper](https://github.com/sunshinejr/Moya-ModelMapper/) . It has not been tested properly, but the changes are fairly straightforward.