### PR TITLE
Should transition to BaseMappable

### DIFF
--- a/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
+++ b/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
@@ -7,7 +7,7 @@ extension SignalProducerType where Value == Moya.Response, Error == Moya.Error {
 
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: Mappable>(type: T.Type) -> SignalProducer<T, Error> {
+  public func mapObject<T: BaseMappable>(type: T.Type) -> SignalProducer<T, Error> {
     return producer.flatMap(.Latest) { response -> SignalProducer<T, Error> in
       return unwrapThrowable { try response.mapObject(T) }
     }
@@ -16,7 +16,7 @@ extension SignalProducerType where Value == Moya.Response, Error == Moya.Error {
   /// Maps data received from the signal into an array of objects which implement the Mappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: Mappable>(type: T.Type) -> SignalProducer<[T], Error> {
+  public func mapArray<T: BaseMappable>(type: T.Type) -> SignalProducer<[T], Error> {
     return producer.flatMap(.Latest) { response -> SignalProducer<[T], Error> in
       return unwrapThrowable { try response.mapArray(T) }
     }

--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -13,7 +13,7 @@ public extension Response {
 
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: Mappable>(type: T.Type) throws -> T {
+  public func mapObject<T: BaseMappable>(type: T.Type) throws -> T {
     guard let object = Mapper<T>().map(try mapJSON()) else {
       throw Error.JSONMapping(self)
     }
@@ -23,7 +23,7 @@ public extension Response {
   /// Maps data received from the signal into an array of objects which implement the Mappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: Mappable>(type: T.Type) throws -> [T] {
+  public func mapArray<T: BaseMappable>(type: T.Type) throws -> [T] {
     guard let objects = Mapper<T>().mapArray(try mapJSON()) else {
       throw Error.JSONMapping(self)
     }

--- a/Source/RxSwift/Observable+ObjectMapper.swift
+++ b/Source/RxSwift/Observable+ObjectMapper.swift
@@ -16,7 +16,7 @@ public extension ObservableType where E == Response {
   /// Maps data received from the signal into an object
   /// which implements the Mappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: Mappable>(type: T.Type) -> Observable<T> {
+  public func mapObject<T: BaseMappable>(type: T.Type) -> Observable<T> {
     return flatMap { response -> Observable<T> in
         return Observable.just(try response.mapObject(T))
       }
@@ -25,7 +25,7 @@ public extension ObservableType where E == Response {
   /// Maps data received from the signal into an array of objects
   /// which implement the Mappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: Mappable>(type: T.Type) -> Observable<[T]> {
+  public func mapArray<T: BaseMappable>(type: T.Type) -> Observable<[T]> {
     return flatMap { response -> Observable<[T]> in
         return Observable.just(try response.mapArray(T))
       }


### PR DESCRIPTION
Hi,

Recent updates to ObjectMapper lifted the restriction on implementing init(map:) but the current Moya-ObjectMapper expects the objects conform to Mappable instead of BaseMappable. I'm opening this PR in a unmergeable state so that I remember to finish it tomorrow. But I'd be glad if you just take a look. Thanks!