### PR TITLE
Updated to work with new object mapper version

### DIFF
--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -14,7 +14,7 @@ public extension Response {
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
   public func mapObject<T: BaseMappable>(_ type: T.Type) throws -> T {
-    guard let object = Mapper<T>().map(try mapJSON()) else {
+    guard let object = Mapper<T>().map(JSONObject: try mapJSON()) else {
       throw Error.jsonMapping(self)
     }
    return object
@@ -24,7 +24,7 @@ public extension Response {
   /// protocol.
   /// If the conversion fails, the signal errors.
   public func mapArray<T: BaseMappable>(_ type: T.Type) throws -> [T] {
-    guard let objects = Mapper<T>().mapArray(try mapJSON()) else {
+    guard let array = try mapJSON() as? [[String : Any]], let objects = Mapper<T>().mapArray(JSONArray: array) else {
       throw Error.jsonMapping(self)
     }
     return objects


### PR DESCRIPTION
ObjectMapper API was updated again thus breaking this library. This pull request fixes it.