### PR TITLE
Updated for Moya 8

### DIFF
--- a/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
+++ b/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
@@ -3,7 +3,7 @@ import Moya
 import ObjectMapper
 
 /// Extension for processing Responses into Mappable objects through ObjectMapper
-extension SignalProducerProtocol where Value == Moya.Response, Error == Moya.Error {
+extension SignalProducerProtocol where Value == Moya.Response, Error == MoyaError {
 
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
@@ -24,10 +24,10 @@ extension SignalProducerProtocol where Value == Moya.Response, Error == Moya.Err
 }
 
 /// Maps throwable to SignalProducer
-private func unwrapThrowable<T>(_ throwable: () throws -> T) -> SignalProducer<T, Moya.Error> {
+private func unwrapThrowable<T>(_ throwable: () throws -> T) -> SignalProducer<T, MoyaError> {
   do {
     return SignalProducer(value: try throwable())
   } catch {
-    return SignalProducer(error: error as! Moya.Error)
+    return SignalProducer(error: error as! MoyaError)
   }
 }

--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -15,7 +15,7 @@ public extension Response {
   /// If the conversion fails, the signal errors.
   public func mapObject<T: BaseMappable>(_ type: T.Type) throws -> T {
     guard let object = Mapper<T>().map(JSONObject: try mapJSON()) else {
-      throw Error.jsonMapping(self)
+      throw MoyaError.jsonMapping(self)
     }
    return object
   }
@@ -25,7 +25,7 @@ public extension Response {
   /// If the conversion fails, the signal errors.
   public func mapArray<T: BaseMappable>(_ type: T.Type) throws -> [T] {
     guard let array = try mapJSON() as? [[String : Any]], let objects = Mapper<T>().mapArray(JSONArray: array) else {
-      throw Error.jsonMapping(self)
+      throw MoyaError.jsonMapping(self)
     }
     return objects
   }
@@ -49,7 +49,7 @@ public extension Response {
   /// If the conversion fails, the signal errors.
   public func mapArray<T: ImmutableMappable>(_ type: T.Type) throws -> [T] {
     guard let array = try mapJSON() as? [[String : Any]] else {
-      throw Error.jsonMapping(self)
+      throw MoyaError.jsonMapping(self)
     }
     return try Mapper<T>().mapArray(JSONArray: array)
   }


### PR DESCRIPTION
This is a quick update to fix compilation errors for Moya-ObjectMapper with Moya 8 release. ReactiveCocoa support needs to be checked still.