### PR TITLE
Added support for MapContext in mapObject() and mapArray()

### DIFF
--- a/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
+++ b/Source/ReactiveCocoa/SignalProducer+ObjectMapper.swift
@@ -7,18 +7,18 @@ extension SignalProducerProtocol where Value == Moya.Response, Error == Moya.Err
 
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: BaseMappable>(_ type: T.Type) -> SignalProducer<T, Error> {
+  public func mapObject<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) -> SignalProducer<T, Error> {
     return producer.flatMap(.Latest) { response -> SignalProducer<T, Error> in
-      return unwrapThrowable { try response.mapObject(T) }
+      return unwrapThrowable { try response.mapObject(T, context) }
     }
   }
 
   /// Maps data received from the signal into an array of objects which implement the Mappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: BaseMappable>(_ type: T.Type) -> SignalProducer<[T], Error> {
+  public func mapArray<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) -> SignalProducer<[T], Error> {
     return producer.flatMap(.Latest) { response -> SignalProducer<[T], Error> in
-      return unwrapThrowable { try response.mapArray(T) }
+      return unwrapThrowable { try response.mapArray(T, context) }
     }
   }
 }

--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -13,8 +13,8 @@ public extension Response {
 
   /// Maps data received from the signal into an object which implements the Mappable protocol.
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: BaseMappable>(_ type: T.Type) throws -> T {
-    guard let object = Mapper<T>().map(JSONObject: try mapJSON()) else {
+	public func mapObject<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) throws -> T {
+		guard let object = Mapper<T>(context: context).map(JSONObject: try mapJSON()) else {
       throw MoyaError.jsonMapping(self)
     }
    return object
@@ -23,8 +23,8 @@ public extension Response {
   /// Maps data received from the signal into an array of objects which implement the Mappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: BaseMappable>(_ type: T.Type) throws -> [T] {
-    guard let array = try mapJSON() as? [[String : Any]], let objects = Mapper<T>().mapArray(JSONArray: array) else {
+  public func mapArray<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) throws -> [T] {
+	guard let array = try mapJSON() as? [[String : Any]], let objects = Mapper<T>(context: context).mapArray(JSONArray: array) else {
       throw MoyaError.jsonMapping(self)
     }
     return objects
@@ -40,18 +40,18 @@ public extension Response {
   /// Maps data received from the signal into an object which implements the ImmutableMappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: ImmutableMappable>(_ type: T.Type) throws -> T {
-    return try Mapper<T>().map(JSONObject: try mapJSON())
+  public func mapObject<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) throws -> T {
+	return try Mapper<T>(context: context).map(JSONObject: try mapJSON())
   }
 
   /// Maps data received from the signal into an array of objects which implement the ImmutableMappable
   /// protocol.
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: ImmutableMappable>(_ type: T.Type) throws -> [T] {
+  public func mapArray<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) throws -> [T] {
     guard let array = try mapJSON() as? [[String : Any]] else {
       throw MoyaError.jsonMapping(self)
     }
-    return try Mapper<T>().mapArray(JSONArray: array)
+	return try Mapper<T>(context: context).mapArray(JSONArray: array)
   }
 
 }

--- a/Source/RxSwift/Observable+ObjectMapper.swift
+++ b/Source/RxSwift/Observable+ObjectMapper.swift
@@ -16,18 +16,18 @@ public extension ObservableType where E == Response {
   /// Maps data received from the signal into an object
   /// which implements the Mappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: BaseMappable>(_ type: T.Type) -> Observable<T> {
+	public func mapObject<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) -> Observable<T> {
     return flatMap { response -> Observable<T> in
-        return Observable.just(try response.mapObject(T.self))
+		return Observable.just(try response.mapObject(T.self, context: context))
       }
   }
 
   /// Maps data received from the signal into an array of objects
   /// which implement the Mappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: BaseMappable>(_ type: T.Type) -> Observable<[T]> {
+	public func mapArray<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) -> Observable<[T]> {
     return flatMap { response -> Observable<[T]> in
-        return Observable.just(try response.mapArray(T.self))
+		return Observable.just(try response.mapArray(T.self, context: context))
       }
   }
 }
@@ -40,18 +40,18 @@ public extension ObservableType where E == Response {
   /// Maps data received from the signal into an object
   /// which implements the ImmutableMappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
-  public func mapObject<T: ImmutableMappable>(_ type: T.Type) -> Observable<T> {
+  public func mapObject<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) -> Observable<T> {
     return flatMap { response -> Observable<T> in
-        return Observable.just(try response.mapObject(T.self))
+		return Observable.just(try response.mapObject(T.self, context: context))
       }
   }
 
   /// Maps data received from the signal into an array of objects
   /// which implement the ImmutableMappable protocol and returns the result back
   /// If the conversion fails, the signal errors.
-  public func mapArray<T: ImmutableMappable>(_ type: T.Type) -> Observable<[T]> {
+  public func mapArray<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) -> Observable<[T]> {
     return flatMap { response -> Observable<[T]> in
-        return Observable.just(try response.mapArray(T.self))
+		return Observable.just(try response.mapArray(T.self, context: context))
       }
   }
 }


### PR DESCRIPTION
A `Mapper` object can be created with a `MapContext` object but this possibility wasn't given in the `mapObject()` and `mapArray()` functions.

In the lastest `ObjectMapper`'s version, `shouldIncludesNilValues` is also allowed when creating a `Mapper`, but I'm kinda a noob with creating pods and I wasn't able to update the dependency version to add this support too.