### PR TITLE
Fixed missing optional guard and added arrayMapping error

### DIFF
--- a/Sample/Pods/Moya/Sources/Moya/MoyaError.swift
+++ b/Sample/Pods/Moya/Sources/Moya/MoyaError.swift
@@ -7,6 +7,9 @@ public enum MoyaError: Swift.Error {
 
     /// Indicates a response failed to map to a JSON structure.
     case jsonMapping(Response)
+	
+	/// Indicates a response failed to map to an array of Mappable objects.
+	case arrayMapping(Response)
 
     /// Indicates a response failed to map to a String.
     case stringMapping(Response)
@@ -27,6 +30,7 @@ public extension MoyaError {
         switch self {
         case .imageMapping(let response): return response
         case .jsonMapping(let response): return response
+		case .arrayMapping(let response): return response
         case .stringMapping(let response): return response
         case .statusCode(let response): return response
         case .underlying: return nil
@@ -44,6 +48,8 @@ extension MoyaError: LocalizedError {
             return "Failed to map data to an Image."
         case .jsonMapping:
             return "Failed to map data to JSON."
+		case .arrayMapping:
+			return "Failed to map data to an array of Mappable objects."
         case .stringMapping:
             return "Failed to map data to a String."
         case .statusCode:

--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -27,7 +27,12 @@ public extension Response {
 	guard let array = try mapJSON() as? [[String : Any]] else {
       throw MoyaError.jsonMapping(self)
     }
-    return Mapper<T>(context: context).mapArray(JSONArray: array)
+	
+	guard let arrayOfMappableObjects = Mapper<T>(context: context).mapArray(JSONArray: array) else {
+		throw MoyaError.arrayMapping(self)
+	}
+	
+    return arrayOfMappableObjects
   }
 
 }


### PR DESCRIPTION
I tried to include **Moya-ObjectMapper** in a project using Carthage. But Carthage failed building the framework because of the following error:

The call of `Mapper<T>(context: context).mapArray(JSONArray: array)` inside the **mapArray** function returns an optional.
But `public func mapArray<T: BaseMappable>(_ type: T.Type, context: MapContext? = nil) throws -> [T]` should return a non-optional.

I fixed it using a guard statement which will throw an **arrayMapping** error in the else case.