### PR TITLE
Update ObjectMapper to version 3.0

### DIFF
--- a/Moya-ObjectMapper.podspec
+++ b/Moya-ObjectMapper.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |ss|
     ss.source_files  = "Source/*.swift"
     ss.dependency "Moya", '~> 9.0'
-    ss.dependency "ObjectMapper", '~> 2.2'
+    ss.dependency "ObjectMapper", '~> 3.0'
     ss.framework  = "Foundation"
   end
 


### PR DESCRIPTION
Fix problem of being unable to compile with Swift 4 due to functions used in ObjectMapper 2.x that are now obsolete